### PR TITLE
Fix wrong firefox addons url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img border="0" src="https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_496x150.png" width="172">
 </a>
 <br/>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/github-file-icons/">
+<a href="https://addons.mozilla.org/en-US/firefox/addon/github-file-icon/">
 <img border="0" src="https://addons.cdn.mozilla.net/static/img/addons-buttons/AMO-button_1.png" width="172" height="60">
 </a>
 


### PR DESCRIPTION
Fix #88 
Firefox add-on url should be https://addons.mozilla.org/en-US/firefox/addon/github-file-icon/ instead of https://addons.mozilla.org/en-US/firefox/addon/github-file-icons/