### PR TITLE
Modify `update-assets` script to remove invalid regex for Safari

### DIFF
--- a/scripts/update-assets.mjs
+++ b/scripts/update-assets.mjs
@@ -3,6 +3,7 @@ import { existsSync, createWriteStream, promises as fsPromises } from 'fs';
 import rimraf from 'rimraf';
 import childProcess from 'child_process';
 import { promisify } from 'util';
+import { readFile, writeFile } from 'fs/promises';
 
 const exec = promisify(childProcess.exec);
 
@@ -120,6 +121,11 @@ const downloadDb = async () => {
 
   await downloadFile(icondb);
   console.log('Finished downloading icondb');
+
+  const dbFile = await readFile(icondb.path, 'utf8');
+  const newDbFile = dbFile.replace('|(?<=\\w)', '');
+  await writeFile(icondb.path, newDbFile);
+  console.log('Finished modifying icondb');
 };
 
 /**

--- a/src/file-icons/db/icondb.js
+++ b/src/file-icons/db/icondb.js
@@ -1803,7 +1803,7 @@ module.exports = [
 ["tag-icon",["medium-yellow","medium-yellow"],/^\.?VERSION$/i],
 ["tag-icon",["medium-orange","medium-orange"],/\.pid$/i],
 ["tag-icon",["medium-maroon","medium-maroon"],/\.tld$/i],
-["tag-icon",["medium-green","medium-green"],/(?:\.|^)sha(?:256|sum)?$|(?:\.|^)(?:check|ck|crc(?:32)?|md5|rmd160|sha(?:224|256|384|512|1|2|3)?)?(?:sums?|(?<=\w))$/i,,false,,/\.text\.checksums$/i],
+["tag-icon",["medium-green","medium-green"],/(?:\.|^)sha(?:256|sum)?$|(?:\.|^)(?:check|ck|crc(?:32)?|md5|rmd160|sha(?:224|256|384|512|1|2|3)?)?(?:sums?)$/i,,false,,/\.text\.checksums$/i],
 ["tcl-icon",["dark-orange","dark-orange"],/\.tcl$/i,,false,/tclsh|wish/,/\.tcl$/i,/^Tcl$/i],
 ["tcl-icon",["medium-orange","medium-orange"],/\.adp$/i],
 ["tcl-icon",["medium-red","medium-red"],/\.tm$/i],


### PR DESCRIPTION
This PR will close #123, it changes the `update-assets.mjs` script to modify the icon-db after downloading it.  It doesn't remove the entire line from the file, just the positive lookahead [which is not allowed in Safari (or Firefox)](https://stackoverflow.com/a/58460583/11020515).  From what I can tell, the line will still match fine without it, except for being a little more strict (shouldn't be a huge deal).

Here's an example of the Regex, showing the part that is not allowed: https://regexr.com/6oovg