### PR TITLE
feat: support github file tree view

### DIFF
--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -29,10 +29,16 @@ const fonts = [
   { name: 'Octicons Regular', path: 'fonts/octicons.woff2' },
 ];
 
+const isGithubPage = () => /.*github.*/.test(window.location.hostname);
+
+const isGithubTreeViewPage = () => {
+  if (!isGithubPage()) return false;
+
+  return !!document.querySelector('#repos-file-tree');
+};
+
 const isGithubFilesPage = () => {
-  if (!/.*github.*/.test(window.location.hostname)) {
-    return false;
-  }
+  if (!isGithubPage()) return false;
 
   const pathname = window.location.pathname;
   const filesPageUrlPattern = new RegExp(/^\/.+\/.+\/pull\/\d+\/files$/);
@@ -49,6 +55,16 @@ const getSelector = (hostname: string) => {
             'ul.ActionList>li[id^=file-tree-item-diff-][role=treeitem]>a>span:nth-child(2)',
           iconSelector:
             'ul.ActionList>li[id^=file-tree-item-diff-][role=treeitem]>a>span:first-child',
+          host: Host.GitHub,
+        };
+      }
+
+      if (isGithubTreeViewPage()) {
+        return {
+          filenameSelector:
+            'div.PRIVATE_TreeView-item-content > span.PRIVATE_TreeView-item-content-text > span',
+          iconSelector:
+            'div.PRIVATE_TreeView-item-content > div.PRIVATE_TreeView-item-visual',
           host: Host.GitHub,
         };
       }


### PR DESCRIPTION
Adds support for the new [GitHub code view](https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view) (currently in beta):

![](https://user-images.githubusercontent.com/24722181/226176129-da59ca62-566d-4201-a086-fc482f786b9c.png)

Compared to #144, it uses separate logic from the one used on PR files pages by checking the existence of the `#repos-file-tree` element.

> **Warning**
It doesn't yet support dynamically loaded files (when opening a folder) as the whole extension logic is based on static pages:
>
>![](https://user-images.githubusercontent.com/24722181/226178022-bc2fa6e3-f814-4293-87bd-024acc8808c1.png)
