### PR TITLE
Temporary .txt and .pdf fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ build
 
 # .DS_Store
 .DS_Store
+
+# .idea
+.idea

--- a/src/css/icons.css
+++ b/src/css/icons.css
@@ -8,3 +8,10 @@
   filter: brightness(125%) contrast(150%) drop-shadow(0 0 0 #fff)
     drop-shadow(1px 1px 1px #444);
 }
+
+/* FIXME broken icons */
+.icon-file-pdf::before {
+  font-family: FontAwesome;
+  content: '\f1c1';
+  font-size: 16px;
+}

--- a/src/css/icons.css
+++ b/src/css/icons.css
@@ -15,3 +15,9 @@
   content: '\f1c1';
   font-size: 16px;
 }
+
+.icon-file-text::before {
+  font-family: FontAwesome;
+  content: '\f15c';
+  font-size: 16px;
+}


### PR DESCRIPTION
## Description
Unfortunately, I have not been able to locate the exact source of the error. However, I have temporarily fixed two icons which were addressed in Issues #126 and #128. To remember that this is a temporary solution this was documented in `icons.css`.

During development I've noticed that the `.idea` folder was not yet excluded for development with a JetBrains IDE. This folder is now excluded in the .gitignore.
