### PR TITLE
Fix icon display after DOM has been modified on tree

### DIFF
--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -193,10 +193,12 @@ const replaceGithubFileIcons = (
     add(element) {
       const filenameDom = select(fileSelector, element);
       if (filenameDom) {
-        const iconDom = select(iconSelector, element);
-        if (iconDom) {
-          replaceIcon({ iconDom, filenameDom });
-        }
+        new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
+          const iconDom = select(iconSelector, element);
+          if (iconDom) {
+            replaceIcon({ iconDom, filenameDom });
+          }
+        });
       }
     },
   });
@@ -234,31 +236,6 @@ const init = async () => {
         'svg:not(.icon-directory)'
       );
     }
-
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach(async (n) => {
-          if (n.nodeName === 'UL') {
-            while ((n.textContent as string).includes('Loading...')) {
-              await new Promise((resolve) => setTimeout(resolve, 100));
-            }
-            await new Promise((resolve) => setTimeout(resolve, 0));
-            replaceGithubFileIcons(
-              '.PRIVATE_TreeView-item-content',
-              'span.PRIVATE_TreeView-item-content-text'
-            );
-          }
-        });
-      });
-    });
-
-    observer.observe(
-      document.querySelector('.react-tree-show-tree-items') as Node,
-      {
-        childList: true,
-        subtree: true,
-      }
-    );
   } else {
     update();
     document.addEventListener('pjax:end', update);

--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -1,4 +1,4 @@
-import * as domLoaded from 'dom-loaded';
+import domLoaded from 'dom-loaded';
 import select from 'select-dom';
 import mobile from 'is-mobile';
 import { observe } from 'selector-observer';
@@ -126,11 +126,10 @@ const replaceIcon = ({
   const filename =
     isGitHub && isMobile
       ? getGitHubMobileFilename(filenameDom)
-      : filenameDom.innerText.trim();
+      : filenameDom.textContent?.trim() ?? '';
 
-  let isDirectory = false;
-  if (iconDom) {
-    isDirectory = iconDom.classList.contains('octicon-file-directory');
+  if (iconDom && iconDom.classList.contains('octicon-file-directory')) {
+    return;
   }
 
   const getIconColorMode = (): ColorMode => {
@@ -156,7 +155,7 @@ const replaceIcon = ({
 
   const darkClassName = darkMode ? 'dark' : '';
 
-  if (className && !isDirectory) {
+  if (className) {
     const icon = document.createElement('span');
 
     if (isGitHub) {
@@ -193,12 +192,10 @@ const replaceGithubFileIcons = (
     add(element) {
       const filenameDom = select(fileSelector, element);
       if (filenameDom) {
-        new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
-          const iconDom = select(iconSelector, element);
-          if (iconDom) {
-            replaceIcon({ iconDom, filenameDom });
-          }
-        });
+        const iconDom = select(iconSelector, element);
+        if (iconDom) {
+          replaceIcon({ iconDom, filenameDom });
+        }
       }
     },
   });
@@ -226,7 +223,7 @@ const init = async () => {
       );
 
       replaceGithubFileIcons(
-        '.PRIVATE_TreeView-item-content',
+        '.PRIVATE_TreeView-item-content:has(span.PRIVATE_TreeView-item-content-text > span:not([class]))',
         'span.PRIVATE_TreeView-item-content-text'
       );
 

--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -234,6 +234,31 @@ const init = async () => {
         'svg:not(.icon-directory)'
       );
     }
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach(async (n) => {
+          if (n.nodeName === 'UL') {
+            while ((n.textContent as string).includes('Loading')) {
+              await new Promise((resolve) => setTimeout(resolve, 100));
+            }
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            replaceGithubFileIcons(
+              '.PRIVATE_TreeView-item-content',
+              'span.PRIVATE_TreeView-item-content-text'
+            );
+          }
+        });
+      });
+    });
+
+    observer.observe(
+      document.querySelector('.react-tree-show-tree-items') as Node,
+      {
+        childList: true,
+        subtree: true,
+      }
+    );
   } else {
     update();
     document.addEventListener('pjax:end', update);

--- a/src/ts/content.ts
+++ b/src/ts/content.ts
@@ -239,7 +239,7 @@ const init = async () => {
       mutations.forEach((mutation) => {
         mutation.addedNodes.forEach(async (n) => {
           if (n.nodeName === 'UL') {
-            while ((n.textContent as string).includes('Loading')) {
+            while ((n.textContent as string).includes('Loading...')) {
               await new Promise((resolve) => setTimeout(resolve, 100));
             }
             await new Promise((resolve) => setTimeout(resolve, 0));


### PR DESCRIPTION
### Description

This pull request fixes the icon display after DOM is modified on tree view (Issue #149).

This pull request also fixes the import of domLoaded as it's not well imported and not awaited.

Current Version of Tree View:

https://github.com/homerchen19/github-file-icons/assets/20275620/e99fad80-ceb1-4ffc-8917-6415900b682a

This Pull Request version of Tree View:


https://github.com/homerchen19/github-file-icons/assets/20275620/524cf15a-44ef-44f6-8d86-ce97b932a948

